### PR TITLE
Implement compute_sdf and CUSTOM_index_vertices_by_faces replace (torchsdf)

### DIFF
--- a/kaolin/csrc/bindings.cpp
+++ b/kaolin/csrc/bindings.cpp
@@ -73,6 +73,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
               &unbatched_triangle_distance_forward_cuda);
   metrics.def("unbatched_triangle_distance_backward_cuda",
               &unbatched_triangle_distance_backward_cuda);
+  metrics.def("CUSTOM_unbatched_triangle_distance_forward_cuda",
+              &CUSTOM_unbatched_triangle_distance_forward_cuda);
+  metrics.def("CUSTOM_unbatched_triangle_distance_backward_cuda",
+              &CUSTOM_unbatched_triangle_distance_backward_cuda);
   py::module render = m.def_submodule("render");
   py::module render_mesh = render.def_submodule("mesh");
   render_mesh.def("packed_rasterize_forward_cuda", &packed_rasterize_forward_cuda);

--- a/kaolin/csrc/metrics/unbatched_triangle_distance.cpp
+++ b/kaolin/csrc/metrics/unbatched_triangle_distance.cpp
@@ -37,6 +37,20 @@ void unbatched_triangle_distance_backward_cuda_impl(
     at::Tensor grad_points,
     at::Tensor grad_face_vertices);
 
+void CUSTOM_unbatched_triangle_distance_forward_cuda_impl(
+    at::Tensor points,
+    at::Tensor face_vertices,
+    at::Tensor dist,
+    at::Tensor dist_sign,
+    at::Tensor normals,
+    at::Tensor clst_points);
+
+void CUSTOM_unbatched_triangle_distance_backward_cuda_impl(
+    at::Tensor grad_dist,
+    at::Tensor points,
+    at::Tensor clst_points,
+    at::Tensor grad_points);
+
 #endif  // WITH_CUDA
 
 
@@ -112,5 +126,69 @@ void unbatched_triangle_distance_backward_cuda(
   AT_ERROR("unbatched_triangle_distance_backward not built with CUDA");
 #endif
 }
+
+void CUSTOM_unbatched_triangle_distance_forward_cuda(
+    at::Tensor points,
+    at::Tensor face_vertices,
+    at::Tensor dist,
+    at::Tensor dist_sign,
+    at::Tensor normals,
+    at::Tensor clst_points) {
+  CHECK_CUDA(points);
+  CHECK_CUDA(face_vertices);
+  CHECK_CUDA(dist);
+  CHECK_CUDA(dist_sign);
+  CHECK_CUDA(normals);
+  CHECK_CUDA(clst_points);
+  CHECK_CONTIGUOUS(points);
+  CHECK_CONTIGUOUS(face_vertices);
+  CHECK_CONTIGUOUS(dist);
+  CHECK_CONTIGUOUS(dist_sign);
+  CHECK_CONTIGUOUS(normals);
+  CHECK_CONTIGUOUS(clst_points);
+  const int num_points = points.size(0);
+  const int num_faces = face_vertices.size(0);
+  CHECK_SIZES(points, num_points, 3);
+  CHECK_SIZES(face_vertices, num_faces, 3, 3);
+  CHECK_SIZES(dist, num_points);
+  CHECK_SIZES(dist_sign, num_points);
+  CHECK_SIZES(normals, num_points, 3);
+  CHECK_SIZES(clst_points, num_points, 3);
+#if WITH_CUDA
+  CUSTOM_unbatched_triangle_distance_forward_cuda_impl(
+      points, face_vertices, dist, dist_sign, normals, clst_points);
+#else
+  AT_ERROR("CUSTOM_unbatched_triangle_distance not built with CUDA");
+#endif
+}
+
+void CUSTOM_unbatched_triangle_distance_backward_cuda(
+    at::Tensor grad_dist,
+    at::Tensor points,
+    at::Tensor clst_points,
+    at::Tensor grad_points) {
+  CHECK_CUDA(grad_dist);
+  CHECK_CUDA(points);
+  CHECK_CUDA(clst_points);
+  CHECK_CUDA(grad_points);
+  CHECK_CONTIGUOUS(grad_dist);
+  CHECK_CONTIGUOUS(points);
+  CHECK_CONTIGUOUS(clst_points);
+  CHECK_CONTIGUOUS(grad_points);
+
+  const int num_points = points.size(0);
+  CHECK_SIZES(grad_dist, num_points);
+  CHECK_SIZES(points, num_points, 3);
+  CHECK_SIZES(clst_points, num_points, 3);
+  CHECK_SIZES(grad_points, num_points, 3);
+
+#if WITH_CUDA
+  CUSTOM_unbatched_triangle_distance_backward_cuda_impl(
+      grad_dist, points, clst_points, grad_points);
+#else
+  AT_ERROR("CUSTOM_unbatched_triangle_distance_backward not built with CUDA");
+#endif
+}
+
 
 }  // namespace kaolin

--- a/kaolin/csrc/metrics/unbatched_triangle_distance.h
+++ b/kaolin/csrc/metrics/unbatched_triangle_distance.h
@@ -36,6 +36,20 @@ void unbatched_triangle_distance_backward_cuda(
     at::Tensor grad_points,
     at::Tensor grad_face_vertices);
 
+void CUSTOM_unbatched_triangle_distance_forward_cuda(
+    at::Tensor points,
+    at::Tensor face_vertices,
+    at::Tensor dist,
+    at::Tensor dist_sign,
+    at::Tensor normals,
+    at::Tensor clst_points);
+
+void CUSTOM_unbatched_triangle_distance_backward_cuda(
+    at::Tensor grad_dist,
+    at::Tensor points,
+    at::Tensor clst_points,
+    at::Tensor grad_points);
+
 }  // namespace kaolin
 
 #endif // KAOLIN_METRICS_UNBATCHED_TRIANGLE_DISTANCE_H_

--- a/kaolin/csrc/metrics/unbatched_triangle_distance_cuda.cu
+++ b/kaolin/csrc/metrics/unbatched_triangle_distance_cuda.cu
@@ -473,6 +473,155 @@ void unbatched_triangle_distance_backward_cuda_impl(
   });
 }
 
+template<typename scalar_t, typename vector_t, int BLOCK_SIZE>
+__global__ void CUSTOM_unbatched_triangle_distance_forward_cuda_kernel(
+    const vector_t* points,
+    const vector_t* vertices,
+    int num_points,
+    int num_faces,
+    scalar_t* out_dist,
+    int* out_dist_sign,
+    vector_t* out_normals,
+    vector_t* clst_points) {
+  __shared__ vector_t shm[BLOCK_SIZE * 3];
+
+  for (int start_face_idx = 0; start_face_idx < num_faces; start_face_idx += BLOCK_SIZE) {
+    int num_faces_iter = min(num_faces - start_face_idx, BLOCK_SIZE);
+    for (int j = threadIdx.x; j < num_faces_iter * 3; j += blockDim.x) {
+      shm[j] = vertices[start_face_idx * 3 + j];
+    }
+    __syncthreads();
+    for (int point_idx = threadIdx.x + blockDim.x * blockIdx.x; point_idx < num_points;
+         point_idx += blockDim.x * gridDim.x) {
+      vector_t p = points[point_idx];
+      scalar_t best_dist = INFINITY;
+      int best_dist_sign = 0;
+      vector_t best_normal;
+      vector_t best_clst_point;
+      for (int sub_face_idx = 0; sub_face_idx < num_faces_iter; sub_face_idx++) {
+        vector_t closest_point;
+
+        vector_t v1 = shm[sub_face_idx * 3];
+        vector_t v2 = shm[sub_face_idx * 3 + 1];
+        vector_t v3 = shm[sub_face_idx * 3 + 2];
+
+        vector_t e12 = v2 - v1;
+        vector_t e23 = v3 - v2;
+        vector_t e31 = v1 - v3;
+        vector_t normal = cross(v1 - v2, e31);
+        scalar_t uab = project_edge(v1, e12, p);
+        scalar_t uca = project_edge(v3, e31, p);
+        if (uca > 1 && uab < 0) {
+          closest_point = v1;
+        } else {
+          scalar_t ubc = project_edge(v2, e23, p);
+          if (uab > 1 && ubc < 0) {
+            closest_point = v2;
+          } else if (ubc > 1 && uca < 0) {
+            closest_point = v3;
+          } else {
+            if (in_range(uab) && (is_not_above(v1, e12, normal, p))) {
+              closest_point = point_at(v1, e12, uab);
+            } else if (in_range(ubc) && (is_not_above(v2, e23, normal, p))) {
+              closest_point = point_at(v2, e23, ubc);
+            } else if (in_range(uca) && (is_not_above(v3, e31, normal, p))) {
+              closest_point = point_at(v3, e31, uca);
+            } else {
+              closest_point = project_plane(v1, normal, p);
+            }
+          }
+        }
+        vector_t dist_vec = p - closest_point;
+        vector_t grad_normal = dist_vec * rsqrt(1e-16f + dot(dist_vec, dist_vec));
+        int dist_sign = (dot(dist_vec, normal)>=0)? 1 : -1;
+        float dist = dot(dist_vec, dist_vec);
+        if (sub_face_idx == 0 || best_dist > dist) {
+          best_dist = dist;
+          best_dist_sign = dist_sign;
+          best_normal = grad_normal;
+          best_clst_point = closest_point;
+        }
+      }
+      if (start_face_idx == 0 || out_dist[point_idx] > best_dist) {
+        out_dist[point_idx] = best_dist;
+        out_dist_sign[point_idx] = best_dist_sign;
+        out_normals[point_idx] = best_normal;
+        clst_points[point_idx] = best_clst_point;
+      }
+    }
+    __syncthreads();
+  }
+}
+
+template<typename scalar_t, typename vector_t>
+__global__ void CUSTOM_unbatched_triangle_distance_backward_cuda_kernel(
+    const scalar_t* grad_dist,
+    const vector_t* points,
+    const vector_t* clst_points,
+    int num_points,
+    vector_t* grad_points) {
+  for (int point_id = threadIdx.x + blockIdx.x * blockDim.x; point_id < num_points;
+       point_id += blockDim.x * gridDim.x) {
+    scalar_t grad_out = 2. * grad_dist[point_id];
+    vector_t dist_vec = points[point_id] - clst_points[point_id];
+    dist_vec = dist_vec * grad_out;
+    grad_points[point_id] = dist_vec;
+  }
+}
+
+void CUSTOM_unbatched_triangle_distance_forward_cuda_impl(
+    at::Tensor points,
+    at::Tensor face_vertices,
+    at::Tensor dist,
+    at::Tensor dist_sign,
+    at::Tensor normals,
+    at::Tensor clst_points) {
+  const int num_threads = 512;
+  const int num_points = points.size(0);
+  const int num_blocks = (num_points + num_threads - 1) / num_threads;
+  AT_DISPATCH_FLOATING_TYPES(points.scalar_type(),
+                             "CUSTOM_unbatched_triangle_distance_forward_cuda", [&] {
+    using vector_t = ScalarTypeToVec3<scalar_t>::type;
+    const at::cuda::OptionalCUDAGuard device_guard(at::device_of(points));
+    auto stream = at::cuda::getCurrentCUDAStream();
+    CUSTOM_unbatched_triangle_distance_forward_cuda_kernel<scalar_t, vector_t, 512><<<
+      num_blocks, num_threads, 0, stream>>>(
+        reinterpret_cast<vector_t*>(points.data_ptr<scalar_t>()),
+        reinterpret_cast<vector_t*>(face_vertices.data_ptr<scalar_t>()),
+        points.size(0),
+        face_vertices.size(0),
+        dist.data_ptr<scalar_t>(),
+        dist_sign.data_ptr<int32_t>(),
+        reinterpret_cast<vector_t*>(normals.data_ptr<scalar_t>()),
+        reinterpret_cast<vector_t*>(clst_points.data_ptr<scalar_t>()));
+    CUDA_CHECK(cudaGetLastError());
+  });
+}
+
+void CUSTOM_unbatched_triangle_distance_backward_cuda_impl(
+    at::Tensor grad_dist,
+    at::Tensor points,
+    at::Tensor clst_points,
+    at::Tensor grad_points) {
+
+  DISPATCH_INPUT_TYPES(points.scalar_type(), scalar_t,
+                       "CUSTOM_unbatched_triangle_distance_backward_cuda", [&] {
+    const int num_points = points.size(0);
+    const int num_blocks = (num_points + num_threads - 1) / num_threads;
+    using vector_t = ScalarTypeToVec3<scalar_t>::type;
+    const at::cuda::OptionalCUDAGuard device_guard(at::device_of(points));
+    auto stream = at::cuda::getCurrentCUDAStream();
+    CUSTOM_unbatched_triangle_distance_backward_cuda_kernel<scalar_t, vector_t><<<
+      num_blocks, num_threads, 0, stream>>>(
+        grad_dist.data_ptr<scalar_t>(),
+        reinterpret_cast<vector_t*>(points.data_ptr<scalar_t>()),
+        reinterpret_cast<vector_t*>(clst_points.data_ptr<scalar_t>()),
+        points.size(0),
+        reinterpret_cast<vector_t*>(grad_points.data_ptr<scalar_t>()));
+    CUDA_CHECK(cudaGetLastError());
+  });
+}
+
 }  // namespace kaolin
 
 #undef PRIVATE_CASE_TYPE_AND_VAL

--- a/kaolin/csrc/utils.h
+++ b/kaolin/csrc/utils.h
@@ -19,6 +19,15 @@
 #include <typeinfo>
 #include <cuda.h>
 
+#define CUDA_CHECK(condition) \
+  /* Code block avoids redefinition of cudaError_t error */ \
+  do { \
+    cudaError_t error = condition; \
+    if (error != cudaSuccess) { \
+      AT_ERROR("CUDA error: ", cudaGetErrorString(error)); \
+    } \
+  } while (0)
+
 #define PRIVATE_CASE_TYPE(ENUM_TYPE, TYPE, TYPE_NAME, ...) \
   case ENUM_TYPE: { \
     using TYPE_NAME = TYPE; \


### PR DESCRIPTION
The purpose of this PR is to add the functions `compute_sdf` and `CUSTOM_index_vertices_by_faces` to `kaolin.metrics.trianglemesh`.

This is the same functionality offered by torchsdf (https://github.com/wrc042/TorchSDF/tree/main). However, that repository could not be built for pytorch 2.1.2 and cuda 11.8 (it worked for pytorch 1.10 and cuda 11.3). 

We make this with only code additions instead of code modifications for simplicity and backwards compatibility. Most new functions start with `CUSTOM_` if there was an original function to make it clear what was changed. For maintenance and understanding, we recommend comparing the `CUSTOM_` functions with their original functions.

Note that this functionality is similar to using `kaolin.metrics.trianglemesh.point_to_mesh_distance` and `kaolin.ops.mesh.check_sign`, but this does not directly return the closest point on the mesh and the normal (direction between the query point and closest point on the mesh). 

